### PR TITLE
Write directly to j's stdin and skip csv parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "url": "git://github.com/dominictarr/excel-stream.git"
   },
   "dependencies": {
-    "JSONStream": "~0.8.2",
+    "JSONStream": "~1.0.4",
     "concat-stream": "^1.4.6",
     "duplexer": "~0.1.1",
-    "j": "^0.3.8",
-    "minimist": "^0.2.0",
+    "j": "~0.4.3",
+    "minimist": "~1.1.1",
     "win-spawn": "^2.0.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "minimist": "~1.1.1",
     "win-spawn": "^2.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "tape": "~4.0.0"
+  },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "tape test.js"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -11,12 +11,9 @@
   "dependencies": {
     "JSONStream": "~0.8.2",
     "concat-stream": "^1.4.6",
-    "csv-stream": "~0.1.3",
     "duplexer": "~0.1.1",
     "j": "^0.3.8",
     "minimist": "^0.2.0",
-    "osenv": "~0.0.3",
-    "through": "~2.3.4",
     "win-spawn": "^2.0.0"
   },
   "devDependencies": {},

--- a/test.js
+++ b/test.js
@@ -1,0 +1,17 @@
+var test = require('tape')
+var excel = require('./')
+var concat = require('concat-stream')
+
+test('csv to json', function(t){
+  var stream = excel()
+
+  stream.pipe(concat(function(data){
+    // for rounding differences
+    data[0].a = data[0].a.toFixed(1)
+
+    t.deepEqual(data, [{ a: '0.3', c: -2}, { a: 'a', b: 'b', c: 'c' }])
+    t.end()
+  }))
+
+  stream.end('a,b,c\n0.3,,-2\na,b,c')
+})


### PR DESCRIPTION
I had some problems with excel-stream:
- did not support European Excel files (1,23 instead of 1.23)
- csv-stream didn't handle j's quoted keys very well, resulting in keys like `"name` or `name"`.

I first tried replacing the csv-stream dependency with the superior csv-parser, which solved problem 2. But I then realized `j` can output JSON too. It writes the raw numbers in that case (and takes care of problem 1), so excel-stream doesn't need to coerce anything. And of course, no CSV parsing necessary. Additionally, excel-stream writes directly to j's stdin with this PR.
